### PR TITLE
Enqueue initializer functions instead of triggering import promises immediately

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
-const mockPromises = [];
+const mockInitializers = [];
 
 module.exports = function preloadAll() {
-  if (mockPromises.length) {
-    const promises = mockPromises.slice();
-    mockPromises.length = 0;
-    // While loading the components in `mockPromises`, more components may have
-    // been dynamically loaded, adding more promises we should wait for.
+  if (mockInitializers.length) {
+    const promises = mockInitializers.map(preload => preload());
+    mockInitializers.length = 0;
+    // While loading the components in this round of initializers, more
+    // components may have been dynamically loaded, adding more promises we
+    // should wait for.
     return Promise.all(promises).then(preloadAll);
   } else {
     return Promise.resolve();
@@ -17,7 +18,7 @@ jest.doMock("next/dynamic", () => {
 
   const mockDynamic = (...args) => {
     const LoadableComponent = dynamic(...args);
-    mockPromises.push(LoadableComponent.preload());
+    mockInitializers.push(() => LoadableComponent.preload());
     return LoadableComponent;
   };
 


### PR DESCRIPTION
Instead of calling `preload` on each dynamic component as it's created, we instead enqueue a function that will call `preload`. This will defer the actual loading until the developer calls `preloadAll`.