### PR TITLE
Use virtual mock for greater flexibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,25 +2,36 @@ const mockInitializers = [];
 
 module.exports = function preloadAll() {
   if (mockInitializers.length) {
-    const promises = mockInitializers.map(preload => preload());
+    // Copy and empty out `mockInitializers` right away so that any newly
+    // enqueued components are found in the next pass.
+    const initializers = mockInitializers.slice();
     mockInitializers.length = 0;
     // While loading the components in this round of initializers, more
-    // components may have been dynamically loaded, adding more promises we
-    // should wait for.
-    return Promise.all(promises).then(preloadAll);
+    // components may have been dynamically imported, adding more initializers
+    // we should run and await.
+    return Promise.all(initializers.map(preload => preload())).then(preloadAll);
   } else {
     return Promise.resolve();
   }
 };
 
-jest.doMock("next/dynamic", () => {
-  const { default: dynamic } = jest.requireActual("next/dynamic");
+jest.doMock(
+  "next/dynamic",
+  () => {
+    const { default: dynamic } = jest.requireActual("next/dynamic");
 
-  const mockDynamic = (...args) => {
-    const LoadableComponent = dynamic(...args);
-    mockInitializers.push(() => LoadableComponent.preload());
-    return LoadableComponent;
-  };
+    const mockDynamic = (...args) => {
+      const LoadableComponent = dynamic(...args);
+      mockInitializers.push(() => LoadableComponent.preload());
+      return LoadableComponent;
+    };
 
-  return mockDynamic;
-});
+    return mockDynamic;
+  },
+  // In order to more easily include this feature in shared Jest setups (like
+  // presets), use `virtual: true` to avoid throwing an error when `next` isn't
+  // actually installed.
+  {
+    virtual: true
+  }
+);


### PR DESCRIPTION
* It would be nice to allow Jest config presets to offer this feature without users actually needing Next.js installed in every project. This uses `virtual: true` on the mock so that it's harmless if used in a package without `next`.
* Empty out `mockInitializers` before running any `preload`, for more bulletproof capturing of any newly loaded components.